### PR TITLE
FIx map rendering and json from mongo

### DIFF
--- a/Coursework/templates/server.js
+++ b/Coursework/templates/server.js
@@ -85,9 +85,9 @@ app.get('/munromap', function(req,res) {
     });
 */
 
-    db.collection('munros').find({},function(err,result){
-        res.send(result);
-    });
+    //db.collection('munros').find({},function(err,result){
+     //   res.send(result);
+   // });
 
 
     session.loggedin = true;


### PR DESCRIPTION
res.send and res.render in one route will force the connection to close, causeing a 502 or 500 error